### PR TITLE
Se arregla el problema de los mensajes repetidos y del "currentColor"

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,28 +23,23 @@ function App() {
     client.connect({ channels: ['afor_digital'] })
 
     client.on('message', ({ username, message, userInfo }) => {
-      console.log(userInfo)
       if (!message.toLowerCase().startsWith('!p')) return
       if (message.length > 150) return
       const slicedMessage = message.slice(2)
-      questions.filter((question) => {
+      /* questions.filter((question) => {
         question.message === slicedMessage
-      })
-      setQuestions([
+      }) */
+      setQuestions((questions) => [
         ...questions,
         {
           user: username,
           message: slicedMessage,
           answered: false,
-          userColor: userInfo.color
+          userColor: userInfo.color === 'currentColor' ? 'red' : userInfo.color
         }
       ])
     })
-
-    return () => {
-      client.close('message')
-    }
-  }, [questions])
+  }, [])
 
   const swipeMode = () => {
     if (mode === 'DEFAULT') {


### PR DESCRIPTION
- En el useEffect donde se llama a ´connect´ se le esta pasando como array de dependecias "questions" lo que causa que ese useEffect se vuelva a llamar y provoque que se vuelva a conectar y a crear mas eventos de cuando se reciben mensajes, por lo cual causa problemas inesperados, la solución es eliminar del array de dependecias ´questions´.
- Se elimina la función de retorno del useEffect ya que 'client.close()' es para otro uso (que yo considero interno de la librería de mtmi)
- Aprovechando la modificación de esta parte del código, cuando se lee el color del usuario, en vez de guardar 'currentColor" se pone un color por defecto "red" (que se puede modificar, en este caso elegí uno al azar).